### PR TITLE
 No module named 'List'

### DIFF
--- a/nnunet/training/network_training/nnUNetTrainer.py
+++ b/nnunet/training/network_training/nnUNetTrainer.py
@@ -18,6 +18,7 @@ from collections import OrderedDict
 from multiprocessing import Pool
 from time import sleep
 from typing import Tuple
+from typing import List
 
 import matplotlib
 import numpy as np


### PR DESCRIPTION
Latest version of nnUNet throws NameError.

Fixed by adding
`from typing import List`